### PR TITLE
fix(android): keep PDF generation working across Activity recreation

### DIFF
--- a/kmpdf/src/androidMain/kotlin/io/github/bigboyapps/kmpdf/KmPdfGenerator.android.kt
+++ b/kmpdf/src/androidMain/kotlin/io/github/bigboyapps/kmpdf/KmPdfGenerator.android.kt
@@ -1,24 +1,25 @@
 package io.github.bigboyapps.kmpdf
 
 import android.app.Activity
+import android.app.Application
 import android.content.Context
 import android.content.Intent
+import android.graphics.Bitmap
 import android.graphics.pdf.PdfDocument
+import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.dp
 import androidx.core.content.FileProvider
 import androidx.core.graphics.createBitmap
 import androidx.core.net.toUri
 import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -29,31 +30,89 @@ import android.graphics.Canvas as AndroidCanvas
 
 private val logger = Logger.withTag("KmPdfGenerator")
 
+/** Supersampling factor applied while rasterizing each page for sharper output. */
+private const val RENDER_SCALE = 2f
+
+/** Delay (ms) after attaching a page so its composition can settle before measuring. */
+private const val COMPOSE_SETTLE_DELAY_MS = 200L
+
+/** Delay (ms) after layout so any follow-up recomposition is applied before drawing. */
+private const val DRAW_SETTLE_DELAY_MS = 100L
+
+/** How many times a single page render is retried when the host Activity is torn down mid-render. */
+private const val MAX_PAGE_RENDER_ATTEMPTS = 5
+
+/** Delay (ms) between page-render attempts while waiting for a live Activity to become available. */
+private const val ACTIVITY_REACQUIRE_DELAY_MS = 200L
+
+/** Off-screen translation used to keep the transient render view out of view while it draws. */
+private const val OFFSCREEN_TRANSLATION = -10_000f
+
 actual fun createKmPdfGenerator(): KmPdfGenerator = AndroidKmPdfGenerator()
 
 private var applicationContext: Context? = null
+
+/** Activity supplied to [initKmPdfGenerator]; used as a fallback and by [sharePdf]. */
 private var activityRef: WeakReference<Activity>? = null
+
+/**
+ * The current foreground Activity, tracked across recreation (rotation, theme/locale changes) by
+ * [activityTracker]. Rendering always uses this rather than a single Activity captured at init
+ * time, so a destroyed Activity is never reused — the root cause of the
+ * "Cannot locate windowRecomposer" crash.
+ */
+private var currentActivityRef: WeakReference<Activity>? = null
+private var activityTrackerRegistered = false
+
+private fun liveActivity(): Activity? = currentActivityRef?.get() ?: activityRef?.get()
+
+private val activityTracker = object : Application.ActivityLifecycleCallbacks {
+    override fun onActivityResumed(activity: Activity) {
+        currentActivityRef = WeakReference(activity)
+    }
+
+    override fun onActivityDestroyed(activity: Activity) {
+        if (currentActivityRef?.get() === activity) {
+            currentActivityRef = null
+        }
+    }
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
+    override fun onActivityStarted(activity: Activity) = Unit
+    override fun onActivityPaused(activity: Activity) = Unit
+    override fun onActivityStopped(activity: Activity) = Unit
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
+}
 
 /**
  * Initializes the KmPdfGenerator with the given context.
  *
- * **Note**: As of version 1.1.0, this function is called automatically via a ContentProvider
- * and manual initialization is typically not required. You only need to call this manually if:
- * - You disabled auto-initialization in your AndroidManifest.xml
- * - You need to re-initialize after the Activity reference was lost
+ * On Android this is normally invoked automatically at startup by [KmPdfInitializer] (a
+ * ContentProvider), so manual initialization is usually unnecessary. When given an [Application]
+ * (or any context whose application context is an [Application]) it registers a lifecycle listener
+ * that keeps track of the current foreground Activity, so PDF generation always renders against a
+ * live Activity and survives Activity recreation while generation is in progress.
  *
- * @param context The Android context. If this is an Activity, it will be held as a weak reference
- *                for rendering Composables. The application context is also stored for file operations.
+ * @param context The Android context. The application context is stored for file operations and
+ *                Activity tracking. If [context] is an [Activity] it is also held as a
+ *                [WeakReference] and used as a fallback and by [sharePdf].
  */
 fun initKmPdfGenerator(context: Context) {
     applicationContext = context.applicationContext
     if (context is Activity) {
         activityRef = WeakReference(context)
+        currentActivityRef = WeakReference(context)
+    }
+    (context.applicationContext as? Application)?.let { app ->
+        if (!activityTrackerRegistered) {
+            app.registerActivityLifecycleCallbacks(activityTracker)
+            activityTrackerRegistered = true
+        }
     }
 }
 
 actual fun sharePdf(uri: String, title: String) {
-    val activity = activityRef?.get() ?: return
+    val activity = liveActivity() ?: return
     val context = applicationContext ?: return
 
     try {
@@ -80,6 +139,9 @@ actual fun sharePdf(uri: String, title: String) {
     }
 }
 
+/** Raised when a page cannot be rendered (e.g. no live Activity, or repeated teardown mid-render). */
+private class PdfRenderingException(message: String, cause: Throwable?) : Exception(message, cause)
+
 class AndroidKmPdfGenerator : KmPdfGenerator {
     override suspend fun generatePdf(
         config: PdfConfig,
@@ -87,143 +149,192 @@ class AndroidKmPdfGenerator : KmPdfGenerator {
     ): PdfResult {
         logger.logDebug { "Starting PDF generation: ${config.fileName}" }
         return withContext(Dispatchers.Main) {
-            try {
-                val context = applicationContext
-                    ?: return@withContext PdfResult.Error.NotInitialized().also {
-                        logger.e { "PDF generation failed: KmPdfGenerator not initialized" }
-                    }
-
-                val activity = activityRef?.get()
-                    ?: return@withContext PdfResult.Error.ActivityLost().also {
-                        logger.e { "PDF generation failed: Activity reference lost" }
-                    }
-
-                // Build pages
-                val pageScope = PdfPageScope()
-                pageScope.pages()
-                val pageContents = pageScope.pages
-
-                if (pageContents.isEmpty()) {
-                    return@withContext PdfResult.Error.Unknown("No pages defined")
+            val context = applicationContext
+                ?: return@withContext PdfResult.Error.NotInitialized().also {
+                    logger.e { "PDF generation failed: KmPdfGenerator not initialized" }
                 }
 
-                val widthPt = config.pageSize.width.value.toInt()
-                val heightPt = config.pageSize.height.value.toInt()
+            val pageScope = PdfPageScope()
+            pageScope.pages()
+            val pageContents = pageScope.pages
 
-                val scale = 2f
-                val widthPx = (widthPt * scale).toInt()
-                val heightPx = (heightPt * scale).toInt()
-
-                logger.logDebug { "Rendering ${pageContents.size} pages at ${widthPt}x${heightPt}pt" }
-
-                val pageBitmaps = pageContents.mapIndexed { index, pageContent ->
-                    logger.logDebug { "Rendering page ${index + 1} of ${pageContents.size}" }
-
-                    var composeView: ComposeView? = null
-                    var parentView: ViewGroup? = null
-
-                    try {
-                        composeView = ComposeView(activity).apply {
-                            setContent {
-                                CompositionLocalProvider(LocalDensity provides Density(scale)) {
-                                    pageContent()
-                                }
-                            }
-                            alpha = 0f
-                            translationX = -10000f
-                            translationY = -10000f
-                            clipToPadding = false
-                            clipChildren = false
-                        }
-
-                        parentView = activity.window.decorView.findViewById<ViewGroup>(android.R.id.content)
-                        val layoutParams = FrameLayout.LayoutParams(widthPx, heightPx)
-                        parentView?.addView(composeView, layoutParams)
-
-                        delay(200)
-
-                        composeView.measure(
-                            View.MeasureSpec.makeMeasureSpec(widthPx, View.MeasureSpec.EXACTLY),
-                            View.MeasureSpec.makeMeasureSpec(heightPx, View.MeasureSpec.EXACTLY)
-                        )
-                        composeView.layout(0, 0, widthPx, heightPx)
-
-                        delay(100)
-
-                        val bitmap = withContext(Dispatchers.IO) {
-                            createBitmap(widthPx, heightPx)
-                        }
-                        val canvas = AndroidCanvas(bitmap)
-                        composeView.draw(canvas)
-
-                        bitmap
-                    } finally {
-                        composeView?.let { view ->
-                            parentView?.removeView(view)
-                        }
-                    }
-                }
-
-                logger.logDebug { "All pages rendered, creating PDF" }
-
-                val pdfResult = withContext(Dispatchers.IO) {
-                    try {
-                        val pdfDocument = PdfDocument()
-
-                        pageBitmaps.forEachIndexed { index, bitmap ->
-                            val pageInfo = PdfDocument.PageInfo.Builder(widthPt, heightPt, index + 1).create()
-                            val page = pdfDocument.startPage(pageInfo)
-
-                            val scaleDown = 1f / scale
-
-                            page.canvas.save()
-                            page.canvas.scale(scaleDown, scaleDown)
-                            page.canvas.drawBitmap(bitmap, 0f, 0f, null)
-                            page.canvas.restore()
-
-                            pdfDocument.finishPage(page)
-                            bitmap.recycle()
-                        }
-
-                        val outputDir = File(context.cacheDir, "pdfs").apply { mkdirs() }
-                        val outputFile = File(outputDir, config.fileName)
-
-                        FileOutputStream(outputFile).use { outputStream ->
-                            pdfDocument.writeTo(outputStream)
-                        }
-                        pdfDocument.close()
-                        logger.logDebug { "PDF written to: ${outputFile.absolutePath}" }
-
-                        val fileSize = outputFile.length()
-
-                        val uri = try {
-                            FileProvider.getUriForFile(
-                                context,
-                                "${context.packageName}.fileprovider",
-                                outputFile
-                            ).toString()
-                        } catch (e: Exception) {
-                            outputFile.toURI().toString()
-                        }
-
-                        logger.logInfo { "PDF generation successful: $uri (${pageBitmaps.size} pages, $fileSize bytes)" }
-                        PdfResult.Success(
-                            uri = uri,
-                            filePath = outputFile.absolutePath,
-                            fileSize = fileSize,
-                            pageCount = pageBitmaps.size
-                        )
-                    } catch (e: Exception) {
-                        logger.e(e) { "Failed to create PDF: ${e.message}" }
-                        PdfResult.Error.IOError("Failed to create PDF: ${e.message}", e)
-                    }
-                }
-
-                pdfResult
-            } catch (e: Exception) {
-                logger.e(e) { "Failed to generate PDF: ${e.message}" }
-                PdfResult.Error.Unknown("Failed to generate PDF: ${e.message}", e)
+            if (pageContents.isEmpty()) {
+                return@withContext PdfResult.Error.Unknown("No pages defined")
             }
+
+            val widthPt = config.pageSize.width.value.toInt()
+            val heightPt = config.pageSize.height.value.toInt()
+            val widthPx = (widthPt * RENDER_SCALE).toInt()
+            val heightPx = (heightPt * RENDER_SCALE).toInt()
+
+            logger.logDebug { "Rendering ${pageContents.size} pages at ${widthPt}x${heightPt}pt" }
+
+            val pageBitmaps = try {
+                pageContents.mapIndexed { index, pageContent ->
+                    logger.logDebug { "Rendering page ${index + 1} of ${pageContents.size}" }
+                    renderPage(pageContent, widthPx, heightPx)
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: PdfRenderingException) {
+                logger.e(e) { "PDF rendering failed: ${e.message}" }
+                return@withContext PdfResult.Error.RenderingFailed(
+                    e.message ?: "Failed to render PDF pages",
+                    e.cause
+                )
+            }
+
+            logger.logDebug { "All pages rendered, creating PDF" }
+            writePdf(context, config, pageBitmaps, widthPt, heightPt)
+        }
+    }
+
+    /**
+     * Renders a single page, retrying with the current foreground Activity if the one in use is
+     * torn down mid-render (e.g. the Activity is recreated by a rotation or theme change). If no
+     * live Activity can be acquired across [MAX_PAGE_RENDER_ATTEMPTS], a [PdfRenderingException] is
+     * thrown so the caller can surface a recoverable [PdfResult.Error.RenderingFailed] rather than
+     * letting the underlying crash propagate.
+     */
+    private suspend fun renderPage(
+        pageContent: @Composable () -> Unit,
+        widthPx: Int,
+        heightPx: Int
+    ): Bitmap {
+        var lastError: Throwable? = null
+        repeat(MAX_PAGE_RENDER_ATTEMPTS) {
+            val activity = liveActivity()
+            if (activity == null) {
+                lastError = IllegalStateException("No live Activity available for rendering")
+                delay(ACTIVITY_REACQUIRE_DELAY_MS)
+                return@repeat
+            }
+            try {
+                return renderPageOnActivity(activity, pageContent, widthPx, heightPx)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: IllegalStateException) {
+                // The host window was torn down mid-render (Activity recreated). Re-acquire the
+                // now-current Activity and try again instead of crashing.
+                logger.logDebug { "Page render attempt failed (${e.message}); retrying" }
+                lastError = e
+                delay(ACTIVITY_REACQUIRE_DELAY_MS)
+            }
+        }
+        throw PdfRenderingException(
+            "Failed to render page after $MAX_PAGE_RENDER_ATTEMPTS attempts: ${lastError?.message}",
+            lastError
+        )
+    }
+
+    private suspend fun renderPageOnActivity(
+        activity: Activity,
+        pageContent: @Composable () -> Unit,
+        widthPx: Int,
+        heightPx: Int
+    ): Bitmap {
+        val parentView = activity.window.decorView.findViewById<ViewGroup>(android.R.id.content)
+            ?: throw IllegalStateException("Host Activity has no content view")
+
+        var composeView: ComposeView? = null
+        try {
+            composeView = ComposeView(activity).apply {
+                setContent {
+                    CompositionLocalProvider(LocalDensity provides Density(RENDER_SCALE)) {
+                        pageContent()
+                    }
+                }
+                alpha = 0f
+                translationX = OFFSCREEN_TRANSLATION
+                translationY = OFFSCREEN_TRANSLATION
+                clipToPadding = false
+                clipChildren = false
+            }
+
+            parentView.addView(composeView, FrameLayout.LayoutParams(widthPx, heightPx))
+
+            delay(COMPOSE_SETTLE_DELAY_MS)
+
+            composeView.measure(
+                View.MeasureSpec.makeMeasureSpec(widthPx, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(heightPx, View.MeasureSpec.EXACTLY)
+            )
+            composeView.layout(0, 0, widthPx, heightPx)
+
+            delay(DRAW_SETTLE_DELAY_MS)
+
+            val bitmap = createBitmap(widthPx, heightPx)
+            composeView.draw(AndroidCanvas(bitmap))
+            return bitmap
+        } finally {
+            composeView?.let { view ->
+                try {
+                    parentView.removeView(view)
+                } catch (e: Exception) {
+                    logger.logDebug { "Failed to detach render view: ${e.message}" }
+                }
+            }
+        }
+    }
+
+    private suspend fun writePdf(
+        context: Context,
+        config: PdfConfig,
+        pageBitmaps: List<Bitmap>,
+        widthPt: Int,
+        heightPt: Int
+    ): PdfResult = withContext(Dispatchers.IO) {
+        try {
+            val pdfDocument = PdfDocument()
+
+            pageBitmaps.forEachIndexed { index, bitmap ->
+                val pageInfo = PdfDocument.PageInfo.Builder(widthPt, heightPt, index + 1).create()
+                val page = pdfDocument.startPage(pageInfo)
+
+                val scaleDown = 1f / RENDER_SCALE
+
+                page.canvas.save()
+                page.canvas.scale(scaleDown, scaleDown)
+                page.canvas.drawBitmap(bitmap, 0f, 0f, null)
+                page.canvas.restore()
+
+                pdfDocument.finishPage(page)
+                bitmap.recycle()
+            }
+
+            val outputDir = File(context.cacheDir, "pdfs").apply { mkdirs() }
+            val outputFile = File(outputDir, config.fileName)
+
+            FileOutputStream(outputFile).use { outputStream ->
+                pdfDocument.writeTo(outputStream)
+            }
+            pdfDocument.close()
+            logger.logDebug { "PDF written to: ${outputFile.absolutePath}" }
+
+            val fileSize = outputFile.length()
+
+            val uri = try {
+                FileProvider.getUriForFile(
+                    context,
+                    "${context.packageName}.fileprovider",
+                    outputFile
+                ).toString()
+            } catch (e: Exception) {
+                outputFile.toURI().toString()
+            }
+
+            logger.logInfo { "PDF generation successful: $uri (${pageBitmaps.size} pages, $fileSize bytes)" }
+            PdfResult.Success(
+                uri = uri,
+                filePath = outputFile.absolutePath,
+                fileSize = fileSize,
+                pageCount = pageBitmaps.size
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.e(e) { "Failed to create PDF: ${e.message}" }
+            PdfResult.Error.IOError("Failed to create PDF: ${e.message}", e)
         }
     }
 }


### PR DESCRIPTION
Fixes #3.

## Problem
On Android, `generatePdf()` rendered each page by attaching an off-screen `ComposeView` to a **single host Activity captured once at init time**. If that Activity was recreated while generation was in progress (rotation, dark/light or locale change), the view detached from its window and the next `composeView.measure(...)` threw:

```
java.lang.IllegalStateException: Cannot locate windowRecomposer; View ...ComposeView... is not attached to a window
```

On builds without the surrounding `try/catch` this was an uncaught crash; on current `main` it is swallowed into `PdfResult.Error.Unknown` — either way generation fails and the in-flight work is lost.

## Fix
- Track the **current foreground Activity** via `Application.ActivityLifecycleCallbacks` (registered from `initKmPdfGenerator`, including the auto-init ContentProvider path) instead of reusing a stale reference.
- Render each page against the live Activity; if the host window is torn down mid-render, **re-acquire the current Activity and retry**.
- If no live Activity is available across retries, fail with a recoverable `PdfResult.Error.RenderingFailed` rather than an uncaught exception.
- Propagate `CancellationException` so cancelling the calling scope behaves correctly.

No public API change (`apiCheck` passes).

## Verification (local, on a Pixel emulator)
- ✅ Builds on all targets (`:kmpdf:build`: Android, JVM, iOS×3, wasmJs) + `detekt` + `apiCheck` + `lint`.
- ✅ Renders correct, full-fidelity PDFs (1-page chart/text and 3-page table — verified by rendering the output to images).
- ✅ **Survives Activity recreation:** a 3-page render with **4 Activity relaunches forced mid-render** produced a valid 3-page PDF with no crash and no error.
- ✅ **Before/after:** temporarily reverting to the old code reproduced the exact `Cannot locate windowRecomposer` exception at `measure()` and produced no PDF; the fix produces a valid PDF under identical conditions.