### PR TITLE
fix(ci): actually publish to Maven Central in release workflows

### DIFF
--- a/.github/workflows/publish-only.yml
+++ b/.github/workflows/publish-only.yml
@@ -54,4 +54,4 @@ jobs:
     - name: Publish to Maven Central
       run: |
         echo "Publishing to Maven Central..."
-        ./gradlew :kmpdf:publishAllPublicationsToMavenCentralRepository --no-configuration-cache
+        ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,7 +197,7 @@ jobs:
     - name: Publish to Maven Central
       run: |
         echo "Publishing to Maven Central..."
-        ./gradlew :kmpdf:publishAllPublicationsToMavenCentralRepository --no-configuration-cache
+        ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
 
     - name: Create GitHub Release
       env:


### PR DESCRIPTION
release.yml and publish-only.yml used `:kmpdf:publishAllPublicationsToMavenCentralRepository`, which only stages artifacts to a local repo and never uploads to the Central Portal — so **1.0.1 and 1.1.0 were tagged/GitHub-released but never published to Maven Central** (verified via the Central Portal API: `published:false`).

Switch both workflows to vanniktech's `publishAndReleaseToMavenCentral` (which `publish.yml` already uses and which published 1.0.0 successfully) so the deployment is uploaded and auto-released.

After merge, running `publish-only.yml` will publish the existing 1.1.0 (already on `main`) to Maven Central.