### PR TITLE
fix(ci): don't @-mention commit authors in generated changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
 
           if git log "${LAST_TAG}"..HEAD --merges --pretty=format:"%s" | grep -q "Merge pull request"; then
             echo "### Pull Requests"
-            git log "${LAST_TAG}"..HEAD --merges --pretty=format:"* %s @%an" | grep "Merge pull request" | sed 's/Merge pull request //' | sed 's/ from .*//'
+            git log "${LAST_TAG}"..HEAD --merges --pretty=format:"* %s (%an)" | grep "Merge pull request" | sed 's/Merge pull request //' | sed 's/ from .*//'
             echo ""
           fi
 
@@ -141,7 +141,7 @@ jobs:
           echo ""
 
           echo "### Contributors"
-          git log "${LAST_TAG}"..HEAD --pretty=format:"* @%an" | sort -u
+          git log "${LAST_TAG}"..HEAD --pretty=format:"* %an" | sort -u
           echo ""
         } > CHANGELOG.md
 


### PR DESCRIPTION
The `release.yml` changelog used `git log --pretty="@%an"`, so an author name like "Jared Guttromson" rendered as `@Jared Guttromson` — GitHub turns the `@Jared` into a mention of an **unrelated** user. Switched to the plain author name (`%an`) so release notes never tag a random GitHub user.

The already-published v1.1.0 release notes have also been corrected.